### PR TITLE
Add support of gradient alpha to Recolor

### DIFF
--- a/Packages/jp.keijiro.kino.post-processing/Resources/Recolor.hlsl
+++ b/Packages/jp.keijiro.kino.post-processing/Resources/Recolor.hlsl
@@ -165,9 +165,9 @@ float4 Fragment(Varyings input) : SV_Target
     fill = lum > _ColorKey1.w ? _ColorKey2.rgb : fill;
     fill = lum > _ColorKey2.w ? _ColorKey3.rgb : fill;
 
-    fill = lum > _AlphaKey0.w ? _AlphaKey1.rgb : fillAlpha;
-    fill = lum > _AlphaKey1.w ? _AlphaKey2.rgb : fillAlpha;
-    fill = lum > _AlphaKey2.w ? _AlphaKey3.rgb : fillAlpha;
+    fillAlpha = lum > _AlphaKey0.w ? _AlphaKey1.r : fillAlpha;
+    fillAlpha = lum > _AlphaKey1.w ? _AlphaKey2.r : fillAlpha;
+    fillAlpha = lum > _AlphaKey2.w ? _AlphaKey3.r : fillAlpha;
 
     #ifdef RECOLOR_GRADIENT_EXT
     fill = lum > _ColorKey3.w ? _ColorKey4.rgb : fill;
@@ -175,10 +175,10 @@ float4 Fragment(Varyings input) : SV_Target
     fill = lum > _ColorKey5.w ? _ColorKey6.rgb : fill;
     fill = lum > _ColorKey6.w ? _ColorKey7.rgb : fill;
 
-	fill = lum > _AlphaKey3.w ? _AlphaKey4.rgb : fillAlpha;
-    fill = lum > _AlphaKey4.w ? _AlphaKey5.rgb : fillAlpha;
-    fill = lum > _AlphaKey5.w ? _AlphaKey6.rgb : fillAlpha;
-    fill = lum > _AlphaKey6.w ? _AlphaKey7.rgb : fillAlpha;
+	fillAlpha = lum > _AlphaKey3.w ? _AlphaKey4.r : fillAlpha;
+    fillAlpha = lum > _AlphaKey4.w ? _AlphaKey5.r : fillAlpha;
+    fillAlpha = lum > _AlphaKey5.w ? _AlphaKey6.r : fillAlpha;
+    fillAlpha = lum > _AlphaKey6.w ? _AlphaKey7.r : fillAlpha;
     #endif
 #endif
 

--- a/Packages/jp.keijiro.kino.post-processing/Resources/Recolor.hlsl
+++ b/Packages/jp.keijiro.kino.post-processing/Resources/Recolor.hlsl
@@ -164,11 +164,21 @@ float4 Fragment(Varyings input) : SV_Target
     fill = lum > _ColorKey0.w ? _ColorKey1.rgb : fill;
     fill = lum > _ColorKey1.w ? _ColorKey2.rgb : fill;
     fill = lum > _ColorKey2.w ? _ColorKey3.rgb : fill;
+
+    fill = lum > _AlphaKey0.w ? _AlphaKey1.rgb : fillAlpha;
+    fill = lum > _AlphaKey1.w ? _AlphaKey2.rgb : fillAlpha;
+    fill = lum > _AlphaKey2.w ? _AlphaKey3.rgb : fillAlpha;
+
     #ifdef RECOLOR_GRADIENT_EXT
     fill = lum > _ColorKey3.w ? _ColorKey4.rgb : fill;
     fill = lum > _ColorKey4.w ? _ColorKey5.rgb : fill;
     fill = lum > _ColorKey5.w ? _ColorKey6.rgb : fill;
     fill = lum > _ColorKey6.w ? _ColorKey7.rgb : fill;
+
+	fill = lum > _AlphaKey3.w ? _AlphaKey4.rgb : fillAlpha;
+    fill = lum > _AlphaKey4.w ? _AlphaKey5.rgb : fillAlpha;
+    fill = lum > _AlphaKey5.w ? _AlphaKey6.rgb : fillAlpha;
+    fill = lum > _AlphaKey6.w ? _AlphaKey7.rgb : fillAlpha;
     #endif
 #endif
 

--- a/Packages/jp.keijiro.kino.post-processing/Resources/Recolor.hlsl
+++ b/Packages/jp.keijiro.kino.post-processing/Resources/Recolor.hlsl
@@ -41,6 +41,15 @@ float4 _ColorKey5;
 float4 _ColorKey6;
 float4 _ColorKey7;
 
+float4 _AlphaKey0;
+float4 _AlphaKey1;
+float4 _AlphaKey2;
+float4 _AlphaKey3;
+float4 _AlphaKey4;
+float4 _AlphaKey5;
+float4 _AlphaKey6;
+float4 _AlphaKey7;
+
 TEXTURE2D(_DitherTexture);
 float _DitherStrength;
 
@@ -126,20 +135,31 @@ float4 Fragment(Varyings input) : SV_Target
     float dither = LOAD_TEXTURE2D(_DitherTexture, positionSS % uint2(tw, th)).x;
     dither = (dither - 0.5) * _DitherStrength;
 
-    // Apply fill gradient.
-    float3 fill = _ColorKey0.rgb;
-    float lum = Luminance(c0.rgb) + dither;
+	// Apply fill gradient.
+	float3 fill = _ColorKey0.rgb;
+	float fillAlpha = _AlphaKey0.r;
+	float lum = Luminance(c0.rgb) + dither;
 
 #ifdef RECOLOR_GRADIENT_LERP
-    fill = lerp(fill, _ColorKey1.rgb, saturate((lum - _ColorKey0.w) / (_ColorKey1.w - _ColorKey0.w)));
-    fill = lerp(fill, _ColorKey2.rgb, saturate((lum - _ColorKey1.w) / (_ColorKey2.w - _ColorKey1.w)));
-    fill = lerp(fill, _ColorKey3.rgb, saturate((lum - _ColorKey2.w) / (_ColorKey3.w - _ColorKey2.w)));
-    #ifdef RECOLOR_GRADIENT_EXT
-    fill = lerp(fill, _ColorKey4.rgb, saturate((lum - _ColorKey3.w) / (_ColorKey4.w - _ColorKey3.w)));
-    fill = lerp(fill, _ColorKey5.rgb, saturate((lum - _ColorKey4.w) / (_ColorKey5.w - _ColorKey4.w)));
-    fill = lerp(fill, _ColorKey6.rgb, saturate((lum - _ColorKey5.w) / (_ColorKey6.w - _ColorKey5.w)));
-    fill = lerp(fill, _ColorKey7.rgb, saturate((lum - _ColorKey6.w) / (_ColorKey7.w - _ColorKey6.w)));
-    #endif
+	fill = lerp(fill, _ColorKey1.rgb, saturate((lum - _ColorKey0.w) / (_ColorKey1.w - _ColorKey0.w)));
+	fill = lerp(fill, _ColorKey2.rgb, saturate((lum - _ColorKey1.w) / (_ColorKey2.w - _ColorKey1.w)));
+	fill = lerp(fill, _ColorKey3.rgb, saturate((lum - _ColorKey2.w) / (_ColorKey3.w - _ColorKey2.w)));
+
+	fillAlpha = lerp(fillAlpha, _AlphaKey1.r, saturate((lum - _AlphaKey0.w) / (_AlphaKey1.w - _AlphaKey0.w)));
+	fillAlpha = lerp(fillAlpha, _AlphaKey2.r, saturate((lum - _AlphaKey1.w) / (_AlphaKey2.w - _AlphaKey1.w)));
+	fillAlpha = lerp(fillAlpha, _AlphaKey3.r, saturate((lum - _AlphaKey2.w) / (_AlphaKey3.w - _AlphaKey2.w)));
+
+	#ifdef RECOLOR_GRADIENT_EXT
+		fill = lerp(fill, _ColorKey4.rgb, saturate((lum - _ColorKey3.w) / (_ColorKey4.w - _ColorKey3.w)));
+		fill = lerp(fill, _ColorKey5.rgb, saturate((lum - _ColorKey4.w) / (_ColorKey5.w - _ColorKey4.w)));
+		fill = lerp(fill, _ColorKey6.rgb, saturate((lum - _ColorKey5.w) / (_ColorKey6.w - _ColorKey5.w)));
+		fill = lerp(fill, _ColorKey7.rgb, saturate((lum - _ColorKey6.w) / (_ColorKey7.w - _ColorKey6.w)));
+
+		fillAlpha = lerp(fillAlpha, _AlphaKey4.r, saturate((lum - _AlphaKey3.w) / (_AlphaKey4.w - _AlphaKey3.w)));
+		fillAlpha = lerp(fillAlpha, _AlphaKey5.r, saturate((lum - _AlphaKey4.w) / (_AlphaKey5.w - _AlphaKey4.w)));
+		fillAlpha = lerp(fillAlpha, _AlphaKey6.r, saturate((lum - _AlphaKey5.w) / (_AlphaKey6.w - _AlphaKey5.w)));
+		fillAlpha = lerp(fillAlpha, _AlphaKey7.r, saturate((lum - _AlphaKey6.w) / (_AlphaKey7.w - _AlphaKey6.w)));
+	#endif
 #else
     fill = lum > _ColorKey0.w ? _ColorKey1.rgb : fill;
     fill = lum > _ColorKey1.w ? _ColorKey2.rgb : fill;
@@ -152,8 +172,8 @@ float4 Fragment(Varyings input) : SV_Target
     #endif
 #endif
 
-    float edge = smoothstep(_EdgeThresholds.x, _EdgeThresholds.y, g);
-    float3 cb = lerp(c0.rgb, fill, _FillOpacity);
-    float3 co = lerp(cb, _EdgeColor.rgb, edge * _EdgeColor.a);
-    return float4(co, c0.a);
+	float edge = smoothstep(_EdgeThresholds.x, _EdgeThresholds.y, g);
+	float3 cb = lerp(c0.rgb, fill.rgb, _FillOpacity * fillAlpha);
+	float3 co = lerp(cb, _EdgeColor.rgb, edge * _EdgeColor.a);
+	return float4(co, c0.a);
 }

--- a/Packages/jp.keijiro.kino.post-processing/Runtime/Internal/Utility.cs
+++ b/Packages/jp.keijiro.kino.post-processing/Runtime/Internal/Utility.cs
@@ -38,6 +38,18 @@ namespace Kino.PostProcessing
             Shader.PropertyToID("_ColorKey7")
         };
 
+        static readonly int[] _alphaKeyPropertyIDs = new[]
+{
+            Shader.PropertyToID("_AlphaKey0"),
+            Shader.PropertyToID("_AlphaKey1"),
+            Shader.PropertyToID("_AlphaKey2"),
+            Shader.PropertyToID("_AlphaKey3"),
+            Shader.PropertyToID("_AlphaKey4"),
+            Shader.PropertyToID("_AlphaKey5"),
+            Shader.PropertyToID("_AlphaKey6"),
+            Shader.PropertyToID("_AlphaKey7")
+        };
+
         public static Gradient DefaultGradient {
             get {
                 var g = new Gradient();
@@ -51,12 +63,25 @@ namespace Kino.PostProcessing
             return _colorKeyPropertyIDs[index];
         }
 
+        public static int GetAlphaKeyPropertyID(int index)
+        {
+            return _alphaKeyPropertyIDs[index];
+        }
+
         public static void SetColorKeys(Material material, GradientColorKey[] colorKeys)
         {
             for (var i = 0; i < 8; i++)
                 material.SetVector(
                     GetColorKeyPropertyID(i),
                     colorKeys[Mathf.Min(i, colorKeys.Length - 1)].ToVector()
+                );
+        }
+
+        public static void SetAlphaKeys(Material material, GradientAlphaKey[] alphaKeys)
+        {
+            for (var i = 0; i < 8; i++)
+                material.SetVector(
+                    GetAlphaKeyPropertyID(i),new Vector4(alphaKeys[Mathf.Min(i, alphaKeys.Length - 1)].alpha,0,0, alphaKeys[Mathf.Min(i, alphaKeys.Length - 1)].time)
                 );
         }
     }

--- a/Packages/jp.keijiro.kino.post-processing/Runtime/Recolor.cs
+++ b/Packages/jp.keijiro.kino.post-processing/Runtime/Recolor.cs
@@ -47,6 +47,7 @@ namespace Kino.PostProcessing
 
         Gradient _cachedGradient;
         GradientColorKey [] _cachedColorKeys;
+        GradientAlphaKey[] _cachedAlphaKeys;
 
         DitherType _ditherType;
         Texture2D _ditherTexture;
@@ -91,6 +92,7 @@ namespace Kino.PostProcessing
             {
                 _cachedGradient = fillGradient.value;
                 _cachedColorKeys = _cachedGradient.colorKeys;
+                _cachedAlphaKeys = _cachedGradient.alphaKeys;
             }
 
             Vector2 edgeThresh;
@@ -112,6 +114,7 @@ namespace Kino.PostProcessing
             _material.SetVector(ShaderIDs.EdgeThresholds, edgeThresh);
             _material.SetFloat(ShaderIDs.FillOpacity, fillOpacity.value);
             GradientUtility.SetColorKeys(_material, _cachedColorKeys);
+            GradientUtility.SetAlphaKeys(_material, _cachedAlphaKeys);
 
             _material.SetTexture(ShaderIDs.DitherTexture, _ditherTexture);
             _material.SetFloat(ShaderIDs.DitherStrength, ditherStrength.value);


### PR DESCRIPTION
Add alpha support to recolor gradient in order to support partial Recolor.

This is helpful for instance when you want to recolor only the dark or bright tones and have finer control over the opacity blending.

The nice part is that the gradient keyframes already have an alpha in the UI so this doesn't change anything user facing.

Thanks for the great package :) 